### PR TITLE
멤버 관리 페이지 정렬 및 카메라 권한 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,6 @@ Caddy 리버스 프록시를 통해 `/api/*` 경로로 서비스됩니다.
 | 파일 | 문제 | 상세 |
 |------|------|------|
 | `EventService.java` | `getAllEvents()` 미사용 | 페이지네이션 버전 `getEventsPaged()`만 사용 중 |
-| `UserService.java` | `getAllUsers()` 미사용 | 페이지네이션 버전 `getApprovedUsersPaged()`, `getPendingUsersPaged()`만 사용 중 |
 | `S3Service.java` | `tempClipExists()` 미사용 | temp/clips 경로 확인 메서드, 호출처 없음 |
 | `S3Service.java` | `moveClipFromTemp()` 미사용 | temp → clips 이동 메서드, 호출처 없음 |
 

--- a/README.md
+++ b/README.md
@@ -603,13 +603,17 @@ src/main/java/com/aegis/aegisbackend/
 
 | Method | Path | 설명 |
 |--------|------|------|
-| GET | `/` | 사용자 목록 (페이지네이션) |
+| GET | `/` | 승인된 사용자 목록 (관리자→일반순, 이메일순) |
+| GET | `/pending` | 미승인 사용자 목록 (최신 가입순) |
+| GET | `/pending/count` | 미승인 사용자 수 |
 | GET | `/{id}` | 사용자 상세 |
-| PATCH | `/{id}` | 사용자 수정 |
+| PATCH | `/{id}` | 사용자 수정 (어드민은 카메라 권한 수정 불가) |
 | DELETE | `/{id}` | 사용자 삭제 |
 | PATCH | `/{id}/approve` | 사용자 승인 |
 
 #### GET /api/users
+
+승인된 사용자 목록 조회 (관리자 먼저, 이메일순 정렬)
 
 **Response:** `200 OK` (PageResponse)
 ```json
@@ -621,7 +625,7 @@ src/main/java/com/aegis/aegisbackend/
       "name": "사용자명",
       "role": "user | admin",
       "approved": true,
-      "assignedCameras": ["UUID 배열"] 또는 ["all"],
+      "assignedCameras": ["UUID 배열"],
       "createdAt": "2026-01-31T12:00:00"
     }
   ],
@@ -639,19 +643,21 @@ src/main/java/com/aegis/aegisbackend/
   "name": "사용자명",
   "role": "user | admin",
   "approved": true,
-  "assignedCameras": ["UUID 배열"] 또는 ["all"],
+  "assignedCameras": ["UUID 배열"],
   "createdAt": "2026-01-31T12:00:00"
 }
 ```
 
 #### PATCH /api/users/{id}
 
+> 어드민 사용자는 카메라 권한(assignedCameras) 수정 불가
+
 **Request:**
 ```json
 {
   "name": "string (선택)",
   "role": "user | admin (선택)",
-  "assignedCameras": ["카메라 UUID 배열"] 또는 ["all"] (선택)
+  "assignedCameras": ["카메라 UUID 배열 (선택)"]
 }
 ```
 
@@ -663,7 +669,7 @@ src/main/java/com/aegis/aegisbackend/
   "name": "사용자명",
   "role": "user | admin",
   "approved": true,
-  "assignedCameras": ["UUID 배열"] 또는 ["all"],
+  "assignedCameras": ["UUID 배열"],
   "createdAt": "2026-01-31T12:00:00"
 }
 ```
@@ -687,7 +693,7 @@ src/main/java/com/aegis/aegisbackend/
   "name": "사용자명",
   "role": "user | admin",
   "approved": true,
-  "assignedCameras": ["UUID 배열"] 또는 ["all"],
+  "assignedCameras": ["UUID 배열"],
   "createdAt": "2026-01-31T12:00:00"
 }
 ```
@@ -970,7 +976,7 @@ erDiagram
 ### 권한
 
 - `USER`: 기본 사용자 (할당된 카메라만 접근)
-- `ADMIN`: 모든 카메라 접근, 사용자 관리
+- `ADMIN`: 모든 카메라 접근 (카메라 권한 수정 불가), 사용자 관리
 
 ## SSE 알림 시스템
 
@@ -1112,7 +1118,7 @@ Caddy 리버스 프록시를 통해 `/api/*` 경로로 서비스됩니다.
 | 파일 | 문제 | 상세 |
 |------|------|------|
 | `EventService.java` | `getAllEvents()` 미사용 | 페이지네이션 버전 `getEventsPaged()`만 사용 중 |
-| `UserService.java` | `getAllUsers()` 미사용 | 페이지네이션 버전 `getUsersPaged()`만 사용 중 |
+| `UserService.java` | `getAllUsers()` 미사용 | 페이지네이션 버전 `getApprovedUsersPaged()`, `getPendingUsersPaged()`만 사용 중 |
 | `S3Service.java` | `tempClipExists()` 미사용 | temp/clips 경로 확인 메서드, 호출처 없음 |
 | `S3Service.java` | `moveClipFromTemp()` 미사용 | temp → clips 이동 메서드, 호출처 없음 |
 

--- a/src/main/java/com/aegis/aegisbackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/controller/UserController.java
@@ -24,14 +24,34 @@ public class UserController {
     private final UserService userService;
 
     /**
-     * 사용자 목록 조회 (페이지네이션)
+     * 승인된 사용자 목록 조회 (관리자→일반 순, 이메일순 정렬)
      */
     @GetMapping
-    public ResponseEntity<?> getUsers(
+    public ResponseEntity<?> getApprovedUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        PageResponse<UserDto> users = userService.getUsersPaged(page, size);
+        PageResponse<UserDto> users = userService.getApprovedUsersPaged(page, size);
         return ResponseEntity.ok(users);
+    }
+
+    /**
+     * 미승인 사용자 목록 조회 (최신 가입순 정렬)
+     */
+    @GetMapping("/pending")
+    public ResponseEntity<?> getPendingUsers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        PageResponse<UserDto> users = userService.getPendingUsersPaged(page, size);
+        return ResponseEntity.ok(users);
+    }
+
+    /**
+     * 미승인 사용자 수 조회
+     */
+    @GetMapping("/pending/count")
+    public ResponseEntity<Map<String, Long>> getPendingUsersCount() {
+        long count = userService.countPendingUsers();
+        return ResponseEntity.ok(Map.of("count", count));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/aegis/aegisbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/repository/UserRepository.java
@@ -25,14 +25,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     @Query("SELECT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.id = :id")
     Optional<User> findByIdWithCameras(@Param("id") UUID id);
 
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.email = :email")
-    Optional<User> findByEmailWithCameras(@Param("email") String email);
-
     @Query("SELECT u FROM User u JOIN u.userCameras uc WHERE uc.camera.id = :cameraId")
     List<User> findUsersByCameraId(@Param("cameraId") UUID cameraId);
 
-    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera")
-    List<User> findAllWithCameras();
 
     // 승인된 사용자 페이지네이션 (관리자 먼저, 이메일순 정렬)
     @Query(value = "SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.approved = true ORDER BY u.role ASC, u.email ASC",

--- a/src/main/java/com/aegis/aegisbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/repository/UserRepository.java
@@ -35,7 +35,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     List<User> findAllWithCameras();
 
     // 승인된 사용자 페이지네이션 (관리자 먼저, 이메일순 정렬)
-    @Query(value = "SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.approved = true ORDER BY u.role DESC, u.email ASC",
+    @Query(value = "SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.approved = true ORDER BY u.role ASC, u.email ASC",
            countQuery = "SELECT COUNT(u) FROM User u WHERE u.approved = true")
     Page<User> findApprovedUsersPaged(Pageable pageable);
 

--- a/src/main/java/com/aegis/aegisbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/repository/UserRepository.java
@@ -34,9 +34,18 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera")
     List<User> findAllWithCameras();
 
-    // 페이지네이션 지원
-    @Query(value = "SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera",
-           countQuery = "SELECT COUNT(u) FROM User u")
-    Page<User> findAllWithCamerasPaged(Pageable pageable);
+    // 승인된 사용자 페이지네이션 (관리자 먼저, 이메일순 정렬)
+    @Query(value = "SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.approved = true ORDER BY u.role DESC, u.email ASC",
+           countQuery = "SELECT COUNT(u) FROM User u WHERE u.approved = true")
+    Page<User> findApprovedUsersPaged(Pageable pageable);
+
+    // 미승인 사용자 페이지네이션 (이메일순 정렬)
+    @Query(value = "SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.userCameras uc LEFT JOIN FETCH uc.camera WHERE u.approved = false ORDER BY u.createdAt DESC",
+           countQuery = "SELECT COUNT(u) FROM User u WHERE u.approved = false")
+    Page<User> findPendingUsersPaged(Pageable pageable);
+
+    // 미승인 사용자 수
+    @Query("SELECT COUNT(u) FROM User u WHERE u.approved = false")
+    long countPendingUsers();
 }
 

--- a/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
@@ -43,12 +43,41 @@ public class UserService {
     }
 
     /**
-     * 사용자 목록 조회 (페이지네이션)
+     * 승인된 사용자 목록 조회 (페이지네이션, 관리자→일반 순, 이메일순 정렬)
      */
+    @Transactional(readOnly = true)
+    public PageResponse<UserDto> getApprovedUsersPaged(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size > 0 ? size : DEFAULT_PAGE_SIZE);
+        Page<User> userPage = userRepository.findApprovedUsersPaged(pageable);
+        return PageResponse.from(userPage, this::toUserDto);
+    }
+
+    /**
+     * 미승인 사용자 목록 조회 (페이지네이션, 최신 가입순 정렬)
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<UserDto> getPendingUsersPaged(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size > 0 ? size : DEFAULT_PAGE_SIZE);
+        Page<User> userPage = userRepository.findPendingUsersPaged(pageable);
+        return PageResponse.from(userPage, this::toUserDto);
+    }
+
+    /**
+     * 미승인 사용자 수 조회
+     */
+    @Transactional(readOnly = true)
+    public long countPendingUsers() {
+        return userRepository.countPendingUsers();
+    }
+
+    /**
+     * @deprecated 대신 getApprovedUsersPaged 또는 getPendingUsersPaged 사용
+     */
+    @Deprecated
     @Transactional(readOnly = true)
     public PageResponse<UserDto> getUsersPaged(int page, int size) {
         Pageable pageable = PageRequest.of(page, size > 0 ? size : DEFAULT_PAGE_SIZE);
-        Page<User> userPage = userRepository.findAllWithCamerasPaged(pageable);
+        Page<User> userPage = userRepository.findApprovedUsersPaged(pageable);
         return PageResponse.from(userPage, this::toUserDto);
     }
 

--- a/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
@@ -75,8 +75,8 @@ public class UserService {
             user.setRole(UserRole.fromValue(request.getRole()));
         }
 
-        // 할당된 카메라 업데이트
-        if (request.getAssignedCameras() != null) {
+        // 할당된 카메라 업데이트 (어드민은 카메라 권한 수정 불가 - 항상 전체 접근)
+        if (request.getAssignedCameras() != null && user.getRole() != UserRole.ADMIN) {
             // 기존 할당 삭제
             userCameraRepository.deleteByUserId(userId);
 

--- a/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
@@ -81,19 +81,17 @@ public class UserService {
             userCameraRepository.deleteByUserId(userId);
 
             // 새로운 카메라 할당
-            if (!request.getAssignedCameras().contains("all")) {
-                for (String cameraIdStr : request.getAssignedCameras()) {
-                    UUID cameraId = UUID.fromString(cameraIdStr);
-                    Camera camera = cameraRepository.findById(cameraId)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.CAMERA_NOT_FOUND));
+            for (String cameraIdStr : request.getAssignedCameras()) {
+                UUID cameraId = UUID.fromString(cameraIdStr);
+                Camera camera = cameraRepository.findById(cameraId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.CAMERA_NOT_FOUND));
 
-                    UserCamera userCamera = UserCamera.builder()
-                            .user(user)
-                            .camera(camera)
-                            .build();
+                UserCamera userCamera = UserCamera.builder()
+                        .user(user)
+                        .camera(camera)
+                        .build();
 
-                    userCameraRepository.save(userCamera);
-                }
+                userCameraRepository.save(userCamera);
             }
         }
 

--- a/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/aegis/aegisbackend/domain/user/service/UserService.java
@@ -35,12 +35,6 @@ public class UserService {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
 
-    @Transactional(readOnly = true)
-    public List<UserDto> getAllUsers() {
-        return userRepository.findAllWithCameras().stream()
-                .map(this::toUserDto)
-                .toList();
-    }
 
     /**
      * 승인된 사용자 목록 조회 (페이지네이션, 관리자→일반 순, 이메일순 정렬)
@@ -70,16 +64,6 @@ public class UserService {
         return userRepository.countPendingUsers();
     }
 
-    /**
-     * @deprecated 대신 getApprovedUsersPaged 또는 getPendingUsersPaged 사용
-     */
-    @Deprecated
-    @Transactional(readOnly = true)
-    public PageResponse<UserDto> getUsersPaged(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size > 0 ? size : DEFAULT_PAGE_SIZE);
-        Page<User> userPage = userRepository.findApprovedUsersPaged(pageable);
-        return PageResponse.from(userPage, this::toUserDto);
-    }
 
     @Transactional(readOnly = true)
     public UserDto getUserById(UUID userId) {
@@ -165,8 +149,11 @@ public class UserService {
 
     /** User 엔티티를 UserDto로 변환 */
     public UserDto toUserDto(User user) {
+        // 어드민은 전체 카메라 접근 권한
         List<String> assignedCameras = user.getRole() == UserRole.ADMIN
-                ? List.of("all")
+                ? cameraRepository.findAll().stream()
+                        .map(camera -> camera.getId().toString())
+                        .toList()
                 : userCameraRepository.findCameraIdsByUserId(user.getId())
                         .stream()
                         .map(UUID::toString)


### PR DESCRIPTION
멤버 관리 페이지의 멤버 목록 정렬 방식을 관리자 - 유저, 이메일 순으로 변경.

멤버 관리 페이지의 승인 대기 정렬 방식을 신청 순으로 변경.

멤버 관리 페이지 서버사이드 페이지네이션 추가.

멤버 관리 페이지의 멤버 목록에서 관리자의 카메라 권한을 변경할 수 없도록 수정.